### PR TITLE
Add support for filtering 1D and 2D histograms by `era` and `dqmio_filepath_contains`

### DIFF
--- a/cmsdials/clients/h1d/models.py
+++ b/cmsdials/clients/h1d/models.py
@@ -40,3 +40,5 @@ class LumisectionHistogram1DFilters(OBaseModel):
     run_number: Optional[int] = None
     title: Optional[str] = None
     title_contains: Optional[str] = None
+    era: Optional[str] = None
+    dqmio_filepath_contains: Optional[str] = None

--- a/cmsdials/clients/h2d/models.py
+++ b/cmsdials/clients/h2d/models.py
@@ -46,3 +46,5 @@ class LumisectionHistogram2DFilters(OBaseModel):
     run_number: Optional[int] = None
     title: Optional[str] = None
     title_contains: Optional[str] = None
+    era: Optional[str] = None
+    dqmio_filepath_contains: Optional[str] = None


### PR DESCRIPTION
feat: add filters `era` and `dqmio_filepath_contains` to `LumisectionHistogram1DFilters` and `LumisectionHistogram2DFilters`