### PR TITLE
Updates according to DIALS release v1.0.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,12 +2,19 @@
 # top-most EditorConfig file
 root = true
 
-# Config for all files
 [*]
-insert_final_newline = true
-
-# Config for Python (uncomment what you need)
-[*.py]
 indent_style = space
 indent_size = 4
+charset = utf-8
 trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.{yml,yaml,json}]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.cache-dev
 nosetests.xml
 coverage.xml
 *.cover

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,36 +1,25 @@
-# See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
-    - id: trailing-whitespace
-    - id: end-of-file-fixer
-    - id: check-yaml
-    - id: check-added-large-files
-  - repo: https://github.com/psf/black
-    rev: 24.1.1
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+        exclude: >
+            (?x)^(
+                package-lock\.json
+                poetry\.lock
+            )$
+      - id: fix-byte-order-marker
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: debug-statements
+      - id: detect-private-key
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.2
     hooks:
-    - id: black
-      args: [
-        --line-length=120
-      ]
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
-    hooks:
-    - id: flake8
-      additional_dependencies: [flake8-bugbear]
-      args: [
-        --max-line-length=120,
-        --max-complexity=10
-      ]
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.13.2
-    hooks:
-    - id: isort
-      args: [
-        --atomic,
-        --profile=black,
-        --line-length=120,
-        --skip-gitignore
-      ]
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ from cmsdials import Dials
 from cmsdials.filters import LumisectionHistogram1DFilters
 
 creds = Credentials.from_creds_file()
-dials = Dials(creds, nthreads=2)
+dials = Dials(creds)
 
 # Getting h1d data
 data = dials.h1d.list_all(LumisectionHistogram1DFilters(me="PixelPhase1/Tracks/PXBarrel/charge_PXLayer_2"), max_pages=5)
@@ -64,7 +64,7 @@ data = dials.h1d.list_all(LumisectionHistogram1DFilters(me="PixelPhase1/Tracks/P
 Users are automatically routed to a workspace based on e-groups, but it is possible to overwrite this configuration and inspect data from others workspaces:
 
 ```python
-dials = Dials(creds, workspace="jetmet", nthreads=2)
+dials = Dials(creds, workspace="jetmet")
 ```
 
 ## Available endpoints
@@ -124,10 +124,9 @@ from cmsdials.filters import (
     RunFilters
 )
 
+dials.file_index.list(FileIndexFilters(dataset__regex="2024B"))
 
-dials.file_index.list(FileIndexFilters(page=10))
-
-dials.h1d.list(LumisectionHistogram1DFilters(me="PixelPhase1/Tracks/PXBarrel/charge_PXLayer_2", page=5))
+dials.h1d.list(LumisectionHistogram1DFilters(me="PixelPhase1/Tracks/PXBarrel/charge_PXLayer_2"))
 
 dials.h2d.list_all(LumisectionHistogram2DFilters(me__regex="PXBarrel", ls_number=78, entries__gte=100), max_pages=5)
 
@@ -159,7 +158,7 @@ DEV_CACHE_DIR = ".cache-dev"
 
 auth = AuthClient(base_url=DEV_URL)
 creds = Credentials.from_creds_file(cache_dir=DEV_CACHE_DIR, client=auth)  # Make sure to specify the auth client with overwritten values, using another cache_dir is recommended
-dials = Dials(creds, nthreads=2, base_url=DEV_URL)
+dials = Dials(creds, base_url=DEV_URL)
 
 dials.h2d.list_all(LumisectionHistogram2DFilters(me__regex="EEOT digi occupancy EE +", entries__gte=100, run_number__gte=360392, run_number__lte=365000), max_pages=5)
 ```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ creds = Credentials.from_creds_file()
 dials = Dials(creds, nthreads=2)
 
 # Getting h1d data
-data = dials.h1d.list_all(LumisectionHistogram1DFilters(title="PixelPhase1/Tracks/PXBarrel/charge_PXLayer_2"), max_pages=5)
+data = dials.h1d.list_all(LumisectionHistogram1DFilters(me="PixelPhase1/Tracks/PXBarrel/charge_PXLayer_2"), max_pages=5)
 ```
 
 ### Workspace
@@ -74,11 +74,11 @@ This package interacts with DIALS api endpoints using underlying classes in `Dia
 ### Retrieving a specific object using `get`
 
 ```python
-dials.file_index.get(id=1)
+dials.file_index.get(id=3386119397)
 dials.h1d.get(id=1)
 dials.h2d.get(id=1)
-dials.lumi.get(id=1)
-dials.run.get(id=1)
+dials.lumi.get(dataset_id=14677060, run_number=367094, ls_number=1)
+dials.run.get(dataset_id=14677060, run_number=367094)
 ```
 
 ### Retrieving a list of objects per page using `list`
@@ -94,6 +94,8 @@ dials.run.list()
 ```
 
 ### Retrieving all available pages of a list of objects using `list_all`
+
+Note: Keep in mind that running `list_all` without any filter can take too much time, since you will be retrieving all rows in the database.
 
 ```python
 dials.file_index.list_all()
@@ -123,15 +125,15 @@ from cmsdials.filters import (
 )
 
 
-dials.file_index.list(FileIndexFilters(page="10"))
+dials.file_index.list(FileIndexFilters(page=10))
 
-dials.h1d.list(LumisectionHistogram1DFilters(title="PixelPhase1/Tracks/PXBarrel/charge_PXLayer_2", page="15"))
+dials.h1d.list(LumisectionHistogram1DFilters(me="PixelPhase1/Tracks/PXBarrel/charge_PXLayer_2", page=5))
 
-dials.h2d.list_all(LumisectionHistogram2DFilters(title_contains="EEOT digi occupancy EE +", min_entries=100, min_run_number=360392, max_run_number=365000), max_pages=5)
+dials.h2d.list_all(LumisectionHistogram2DFilters(me__regex="PXBarrel", ls_number=78, entries__gte=100), max_pages=5)
 
 dials.lumi.list_all(LumisectionFilters(run_number=360392), max_pages=5)
 
-dials.run.list_all(RunFilters(min_run_number=360392, max_run_number=365000), max_pages=5)
+dials.run.list_all(RunFilters(run_number__gte=360392, run_number__lte=365000), max_pages=5)
 ```
 
 ### Dials MEs
@@ -159,5 +161,5 @@ auth = AuthClient(base_url=DEV_URL)
 creds = Credentials.from_creds_file(cache_dir=DEV_CACHE_DIR, client=auth)  # Make sure to specify the auth client with overwritten values, using another cache_dir is recommended
 dials = Dials(creds, nthreads=2, base_url=DEV_URL)
 
-dials.h2d.list_all(LumisectionHistogram2DFilters(title_contains="EEOT digi occupancy EE +", min_entries=100, min_run_number=360392, max_run_number=365000), max_pages=5)
+dials.h2d.list_all(LumisectionHistogram2DFilters(me__regex="EEOT digi occupancy EE +", entries__gte=100, run_number__gte=360392, run_number__lte=365000), max_pages=5)
 ```

--- a/cmsdials/clients/file_index/models.py
+++ b/cmsdials/clients/file_index/models.py
@@ -7,11 +7,10 @@ from ...utils.base_model import OBaseModel
 
 
 class FileIndex(BaseModel):
+    dataset_id: int
+    dataset: str = Field(..., max_length=255)
     file_id: int
     file_size: int
-    era: str = Field(..., max_length=5)
-    campaign: str = Field(..., max_length=15)
-    primary_dataset: str = Field(..., max_length=50)
     creation_date: datetime
     last_modification_date: datetime
     logical_file_name: str
@@ -27,10 +26,11 @@ class PaginatedFileIndexList(BaseModel):
 
 
 class FileIndexFilters(OBaseModel):
-    page: Optional[str] = None
-    min_size: Optional[int] = None
-    era: Optional[str] = None
-    campaign: Optional[str] = None
-    primary_dataset: Optional[str] = None
+    page: Optional[int] = None
+    dataset_id: Optional[int] = None
     logical_file_name: Optional[str] = None
+    logical_file_name__regex: Optional[str] = None
     status: Optional[str] = None
+    min_size: Optional[int] = None
+    dataset: Optional[str] = None
+    dataset__regex: Optional[str] = None

--- a/cmsdials/clients/file_index/models.py
+++ b/cmsdials/clients/file_index/models.py
@@ -19,14 +19,13 @@ class FileIndex(BaseModel):
 
 
 class PaginatedFileIndexList(BaseModel):
-    count: int
     next: Optional[AnyUrl]
     previous: Optional[AnyUrl]
     results: List[FileIndex]
 
 
 class FileIndexFilters(OBaseModel):
-    page: Optional[int] = None
+    next_token: Optional[str] = None
     dataset_id: Optional[int] = None
     logical_file_name: Optional[str] = None
     logical_file_name__regex: Optional[str] = None

--- a/cmsdials/clients/h1d/client.py
+++ b/cmsdials/clients/h1d/client.py
@@ -6,4 +6,4 @@ class LumisectionHistogram1DClient(BaseAuthorizedAPIClient):
     data_model = LumisectionHistogram1D
     pagination_model = PaginatedLumisectionHistogram1DList
     filter_class = LumisectionHistogram1DFilters
-    lookup_url = "lumisection-h1d/"
+    lookup_url = "th1/"

--- a/cmsdials/clients/h1d/models.py
+++ b/cmsdials/clients/h1d/models.py
@@ -23,14 +23,13 @@ class LumisectionHistogram1D(BaseModel):
 
 
 class PaginatedLumisectionHistogram1DList(BaseModel):
-    count: int
     next: Optional[AnyUrl]
     previous: Optional[AnyUrl]
     results: List[LumisectionHistogram1D]
 
 
 class LumisectionHistogram1DFilters(OBaseModel):
-    page: Optional[int] = None
+    next_token: Optional[str] = None
     dataset_id: Optional[int] = None
     file_id: Optional[int] = None
     run_number: Optional[int] = None

--- a/cmsdials/clients/h1d/models.py
+++ b/cmsdials/clients/h1d/models.py
@@ -7,10 +7,14 @@ from ...utils.base_model import OBaseModel
 
 class LumisectionHistogram1D(BaseModel):
     hist_id: int
+    dataset: str = Field(..., max_length=255)
+    me: str = Field(..., max_length=255)
+    dataset_id: int
     file_id: int
     run_number: int
+    ls_number: int
+    me_id: int
     ls_id: int
-    title: str = Field(..., max_length=220)
     x_min: float
     x_max: float
     x_bin: float
@@ -26,18 +30,21 @@ class PaginatedLumisectionHistogram1DList(BaseModel):
 
 
 class LumisectionHistogram1DFilters(OBaseModel):
-    page: Optional[str] = None
-    run_number: Optional[int] = None
-    ls_number: Optional[int] = None
-    ls_id: Optional[int] = None
-    title: Optional[str] = None
-    min_run_number: Optional[int] = None
-    max_run_number: Optional[int] = None
-    min_ls_number: Optional[int] = None
-    max_ls_number: Optional[int] = None
-    title_contains: Optional[str] = None
-    min_entries: Optional[int] = None
-    era: Optional[str] = None
-    campaign: Optional[str] = None
-    primary_dataset: Optional[str] = None
+    page: Optional[int] = None
+    dataset_id: Optional[int] = None
     file_id: Optional[int] = None
+    run_number: Optional[int] = None
+    run_number__lte: Optional[int] = None
+    run_number__gte: Optional[int] = None
+    ls_number: Optional[int] = None
+    ls_numbet__lte: Optional[int] = None
+    ls_number__gte: Optional[int] = None
+    me_id: Optional[int] = None
+    ls_id: Optional[int] = None
+    entries__gte: Optional[int] = None
+    dataset: Optional[str] = None
+    dataset__regex: Optional[str] = None
+    logical_file_name: Optional[str] = None
+    logical_file_name__regex: Optional[str] = None
+    me: Optional[str] = None
+    me__regex: Optional[str] = None

--- a/cmsdials/clients/h2d/client.py
+++ b/cmsdials/clients/h2d/client.py
@@ -6,4 +6,4 @@ class LumisectionHistogram2DClient(BaseAuthorizedAPIClient):
     data_model = LumisectionHistogram2D
     pagination_model = PaginatedLumisectionHistogram2DList
     filter_class = LumisectionHistogram2DFilters
-    lookup_url = "lumisection-h2d/"
+    lookup_url = "th2/"

--- a/cmsdials/clients/h2d/models.py
+++ b/cmsdials/clients/h2d/models.py
@@ -7,10 +7,14 @@ from ...utils.base_model import OBaseModel
 
 class LumisectionHistogram2D(BaseModel):
     hist_id: int
+    dataset: str = Field(..., max_length=255)
+    me: str = Field(..., max_length=255)
+    dataset_id: int
     file_id: int
     run_number: int
+    ls_number: int
+    me_id: int
     ls_id: int
-    title: str = Field(..., max_length=220)
     x_min: float
     x_max: float
     x_bin: float
@@ -18,7 +22,7 @@ class LumisectionHistogram2D(BaseModel):
     y_max: float
     y_bin: float
     entries: int
-    data: list[float]
+    data: list[list[float]]
 
 
 class PaginatedLumisectionHistogram2DList(BaseModel):
@@ -29,18 +33,21 @@ class PaginatedLumisectionHistogram2DList(BaseModel):
 
 
 class LumisectionHistogram2DFilters(OBaseModel):
-    page: Optional[str] = None
-    run_number: Optional[int] = None
-    ls_number: Optional[int] = None
-    ls_id: Optional[int] = None
-    title: Optional[str] = None
-    min_run_number: Optional[int] = None
-    max_run_number: Optional[int] = None
-    min_ls_number: Optional[int] = None
-    max_ls_number: Optional[int] = None
-    title_contains: Optional[str] = None
-    min_entries: Optional[int] = None
-    era: Optional[str] = None
-    campaign: Optional[str] = None
-    primary_dataset: Optional[str] = None
+    page: Optional[int] = None
+    dataset_id: Optional[int] = None
     file_id: Optional[int] = None
+    run_number: Optional[int] = None
+    run_number__lte: Optional[int] = None
+    run_number__gte: Optional[int] = None
+    ls_number: Optional[int] = None
+    ls_numbet__lte: Optional[int] = None
+    ls_number__gte: Optional[int] = None
+    me_id: Optional[int] = None
+    ls_id: Optional[int] = None
+    entries__gte: Optional[int] = None
+    dataset: Optional[str] = None
+    dataset__regex: Optional[str] = None
+    logical_file_name: Optional[str] = None
+    logical_file_name__regex: Optional[str] = None
+    me: Optional[str] = None
+    me__regex: Optional[str] = None

--- a/cmsdials/clients/h2d/models.py
+++ b/cmsdials/clients/h2d/models.py
@@ -26,14 +26,13 @@ class LumisectionHistogram2D(BaseModel):
 
 
 class PaginatedLumisectionHistogram2DList(BaseModel):
-    count: int
     next: Optional[AnyUrl]
     previous: Optional[AnyUrl]
     results: list[LumisectionHistogram2D]
 
 
 class LumisectionHistogram2DFilters(OBaseModel):
-    page: Optional[int] = None
+    next_token: Optional[str] = None
     dataset_id: Optional[int] = None
     file_id: Optional[int] = None
     run_number: Optional[int] = None

--- a/cmsdials/clients/lumisection/client.py
+++ b/cmsdials/clients/lumisection/client.py
@@ -1,4 +1,8 @@
+import requests
+from requests.exceptions import HTTPError
+
 from ...utils.api_client import BaseAuthorizedAPIClient
+from ...utils.logger import logger
 from .models import Lumisection, LumisectionFilters, PaginatedLumisectionList
 
 
@@ -7,3 +11,17 @@ class LumisectionClient(BaseAuthorizedAPIClient):
     pagination_model = PaginatedLumisectionList
     filter_class = LumisectionFilters
     lookup_url = "lumisection/"
+
+    def get(self, dataset_id: int, run_number: int, ls_number: int):
+        endpoint_url = f"{self.api_url}{self.lookup_url}{dataset_id}/{run_number}/{ls_number}/"
+        headers = self._build_headers()
+        response = requests.get(endpoint_url, headers=headers)
+
+        try:
+            response.raise_for_status()
+        except HTTPError as err:
+            logger.info(f"Api raw response: {response.text}")
+            raise err
+
+        response = response.json()
+        return self.data_model(**response)

--- a/cmsdials/clients/lumisection/models.py
+++ b/cmsdials/clients/lumisection/models.py
@@ -16,14 +16,13 @@ class Lumisection(BaseModel):
 
 
 class PaginatedLumisectionList(BaseModel):
-    count: int
     next: Optional[AnyUrl]
     previous: Optional[AnyUrl]
     results: list[Lumisection]
 
 
 class LumisectionFilters(OBaseModel):
-    page: Optional[int] = None
+    next_token: Optional[str] = None
     dataset_id: Optional[int] = None
     run_number: Optional[int] = None
     run_number__lte: Optional[int] = None

--- a/cmsdials/clients/lumisection/models.py
+++ b/cmsdials/clients/lumisection/models.py
@@ -1,13 +1,16 @@
 from typing import Optional
 
-from pydantic import AnyUrl, BaseModel
+from pydantic import AnyUrl, BaseModel, Field
 
 from ...utils.base_model import OBaseModel
 
 
 class Lumisection(BaseModel):
-    ls_id: int
+    dataset_id: int
+    dataset: str = Field(..., max_length=255)
+    run_number: int
     ls_number: int
+    ls_id: int
     th1_count: int
     th2_count: int
 
@@ -20,10 +23,13 @@ class PaginatedLumisectionList(BaseModel):
 
 
 class LumisectionFilters(OBaseModel):
-    page: Optional[str] = None
+    page: Optional[int] = None
+    dataset_id: Optional[int] = None
     run_number: Optional[int] = None
+    run_number__lte: Optional[int] = None
+    run_number__gte: Optional[int] = None
     ls_number: Optional[int] = None
-    min_ls_number: Optional[int] = None
-    max_ls_number: Optional[int] = None
-    min_run_number: Optional[int] = None
-    max_run_number: Optional[int] = None
+    ls_number__lte: Optional[int] = None
+    ls_number__gte: Optional[int] = None
+    dataset: Optional[str] = None
+    dataset__regex: Optional[str] = None

--- a/cmsdials/clients/run/client.py
+++ b/cmsdials/clients/run/client.py
@@ -1,4 +1,8 @@
+import requests
+from requests.exceptions import HTTPError
+
 from ...utils.api_client import BaseAuthorizedAPIClient
+from ...utils.logger import logger
 from .models import PaginatedRunList, Run, RunFilters
 
 
@@ -7,3 +11,17 @@ class RunClient(BaseAuthorizedAPIClient):
     pagination_model = PaginatedRunList
     filter_class = RunFilters
     lookup_url = "run/"
+
+    def get(self, dataset_id: int, run_number: int):
+        endpoint_url = f"{self.api_url}{self.lookup_url}{dataset_id}/{run_number}/"
+        headers = self._build_headers()
+        response = requests.get(endpoint_url, headers=headers)
+
+        try:
+            response.raise_for_status()
+        except HTTPError as err:
+            logger.info(f"Api raw response: {response.text}")
+            raise err
+
+        response = response.json()
+        return self.data_model(**response)

--- a/cmsdials/clients/run/models.py
+++ b/cmsdials/clients/run/models.py
@@ -1,11 +1,13 @@
 from typing import Optional
 
-from pydantic import AnyUrl, BaseModel
+from pydantic import AnyUrl, BaseModel, Field
 
 from ...utils.base_model import OBaseModel
 
 
 class Run(BaseModel):
+    dataset_id: int
+    dataset: str = Field(..., max_length=255)
     run_number: int
     ls_count: int
 
@@ -18,6 +20,10 @@ class PaginatedRunList(BaseModel):
 
 
 class RunFilters(OBaseModel):
-    page: Optional[str] = None
-    max_run_number: Optional[int] = None
-    min_run_number: Optional[int] = None
+    page: Optional[int] = None
+    dataset_id: Optional[int] = None
+    run_number: Optional[int] = None
+    run_number__lte: Optional[int] = None
+    run_number__gte: Optional[int] = None
+    dataset: Optional[str] = None
+    dataset__regex: Optional[str] = None

--- a/cmsdials/clients/run/models.py
+++ b/cmsdials/clients/run/models.py
@@ -13,14 +13,13 @@ class Run(BaseModel):
 
 
 class PaginatedRunList(BaseModel):
-    count: int
     next: Optional[AnyUrl]
     previous: Optional[AnyUrl]
     results: list[Run]
 
 
 class RunFilters(OBaseModel):
-    page: Optional[int] = None
+    next_token: Optional[str] = None
     dataset_id: Optional[int] = None
     run_number: Optional[int] = None
     run_number__lte: Optional[int] = None

--- a/cmsdials/cmsdials.py
+++ b/cmsdials/cmsdials.py
@@ -9,11 +9,9 @@ from .clients.run.client import RunClient
 
 
 class Dials:
-    def __init__(
-        self, creds: BaseCredentials, workspace: Optional[str] = None, nthreads: Optional[int] = None, *args, **kwargs
-    ) -> None:
-        self.file_index = FileIndexClient(creds, workspace, nthreads, *args, **kwargs)
-        self.h1d = LumisectionHistogram1DClient(creds, workspace, nthreads, *args, **kwargs)
-        self.h2d = LumisectionHistogram2DClient(creds, workspace, nthreads, *args, **kwargs)
-        self.lumi = LumisectionClient(creds, workspace, nthreads, *args, **kwargs)
-        self.run = RunClient(creds, workspace, nthreads, *args, **kwargs)
+    def __init__(self, creds: BaseCredentials, workspace: Optional[str] = None, *args, **kwargs) -> None:
+        self.file_index = FileIndexClient(creds, workspace, *args, **kwargs)
+        self.h1d = LumisectionHistogram1DClient(creds, workspace, *args, **kwargs)
+        self.h2d = LumisectionHistogram2DClient(creds, workspace, *args, **kwargs)
+        self.lumi = LumisectionClient(creds, workspace, *args, **kwargs)
+        self.run = RunClient(creds, workspace, *args, **kwargs)

--- a/cmsdials/utils/api_client.py
+++ b/cmsdials/utils/api_client.py
@@ -1,6 +1,5 @@
-from concurrent.futures import ThreadPoolExecutor
-from math import ceil
 from typing import Optional
+from urllib.parse import parse_qs, urlparse
 
 import requests
 from requests.exceptions import HTTPError
@@ -42,14 +41,12 @@ class BaseAuthorizedAPIClient(BaseAPIClient):
         self,
         creds: BaseCredentials,
         workspace: Optional[str] = None,
-        nthreads: Optional[int] = None,
         *args: str,
         **kwargs: str,
     ) -> None:
         super().__init__(*args, **kwargs)
         self.creds = creds
         self.workspace = workspace
-        self.nthreads = nthreads or 1
 
     def _build_headers(self) -> dict:
         base = {"accept": "application/json"}
@@ -88,54 +85,25 @@ class BaseAuthorizedAPIClient(BaseAPIClient):
         return self.pagination_model(**response)
 
     def __list_sync(self, filters, max_pages: Optional[int] = None):
-        page = 1
+        next_token = None
         results = []
         is_last_page = False
+        total_pages = 0
 
         while is_last_page is False:
             curr_filters = self.filter_class(**filters.dict())
-            curr_filters.page = page
+            curr_filters.next_token = next_token
             response = self.list(curr_filters)
             results.extend(response.results)
             is_last_page = response.next is None
-            page += 1
-            if max_pages and page > max_pages:
+            next_token = parse_qs(urlparse(response.next).query).get("next_token") if response.next else None
+            total_pages += 1
+            if max_pages and total_pages > max_pages:
                 break
 
         return self.pagination_model(
-            count=response.count, next=None, previous=None, results=results  # No problem re-using last response count
+            next=None, previous=None, results=results  # No problem re-using last response count
         )
-
-    def __list_multithreaded(self, filters, max_pages: Optional[int] = None):
-        results = []
-
-        # Request the first page to compute number of pages
-        curr_filters = self.filter_class(**filters.dict())
-        curr_filters.page = "1"
-        response = self.list(curr_filters)
-        results.extend(response.results)
-        count = response.count
-        n_pages = ceil(response.count / 10)
-        n_pages = max_pages if max_pages is not None and n_pages > max_pages else n_pages
-
-        # If there isn't another page, just return current results
-        if response.next is None:
-            return response
-
-        # Request other pages
-        all_filters = [{**filters.dict(), "page": page} for page in range(2, n_pages + 1)]
-        all_filters = [self.filter_class(**filter) for filter in all_filters]
-        with ThreadPoolExecutor(max_workers=self.nthreads) as executor:
-            jobs = executor.map(self.list, all_filters)
-            del all_filters
-            [results.extend(job_result.results) for job_result in jobs]
-            del jobs
-
-        return self.pagination_model(count=count, next=None, previous=None, results=results)
 
     def list_all(self, filters, max_pages: Optional[int] = None):
-        return (
-            self.__list_sync(filters, max_pages)
-            if self.nthreads is None
-            else self.__list_multithreaded(filters, max_pages)
-        )
+        return self.__list_sync(filters, max_pages)

--- a/poetry.lock
+++ b/poetry.lock
@@ -297,6 +297,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -351,6 +352,32 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "ruff"
+version = "0.4.2"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.4.2-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:8d14dc8953f8af7e003a485ef560bbefa5f8cc1ad994eebb5b12136049bbccc5"},
+    {file = "ruff-0.4.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:24016ed18db3dc9786af103ff49c03bdf408ea253f3cb9e3638f39ac9cf2d483"},
+    {file = "ruff-0.4.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e2e06459042ac841ed510196c350ba35a9b24a643e23db60d79b2db92af0c2b"},
+    {file = "ruff-0.4.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3afabaf7ba8e9c485a14ad8f4122feff6b2b93cc53cd4dad2fd24ae35112d5c5"},
+    {file = "ruff-0.4.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:799eb468ea6bc54b95527143a4ceaf970d5aa3613050c6cff54c85fda3fde480"},
+    {file = "ruff-0.4.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:ec4ba9436a51527fb6931a8839af4c36a5481f8c19e8f5e42c2f7ad3a49f5069"},
+    {file = "ruff-0.4.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6a2243f8f434e487c2a010c7252150b1fdf019035130f41b77626f5655c9ca22"},
+    {file = "ruff-0.4.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8772130a063f3eebdf7095da00c0b9898bd1774c43b336272c3e98667d4fb8fa"},
+    {file = "ruff-0.4.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ab165ef5d72392b4ebb85a8b0fbd321f69832a632e07a74794c0e598e7a8376"},
+    {file = "ruff-0.4.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1f32cadf44c2020e75e0c56c3408ed1d32c024766bd41aedef92aa3ca28eef68"},
+    {file = "ruff-0.4.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:22e306bf15e09af45ca812bc42fa59b628646fa7c26072555f278994890bc7ac"},
+    {file = "ruff-0.4.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:82986bb77ad83a1719c90b9528a9dd663c9206f7c0ab69282af8223566a0c34e"},
+    {file = "ruff-0.4.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:652e4ba553e421a6dc2a6d4868bc3b3881311702633eb3672f9f244ded8908cd"},
+    {file = "ruff-0.4.2-py3-none-win32.whl", hash = "sha256:7891ee376770ac094da3ad40c116258a381b86c7352552788377c6eb16d784fe"},
+    {file = "ruff-0.4.2-py3-none-win_amd64.whl", hash = "sha256:5ec481661fb2fd88a5d6cf1f83403d388ec90f9daaa36e40e2c003de66751798"},
+    {file = "ruff-0.4.2-py3-none-win_arm64.whl", hash = "sha256:cbd1e87c71bca14792948c4ccb51ee61c3296e164019d2d484f3eaa2d360dfaf"},
+    {file = "ruff-0.4.2.tar.gz", hash = "sha256:33bcc160aee2520664bc0859cfeaebc84bb7323becff3f303b8f1f2d81cb4edc"},
+]
 
 [[package]]
 name = "setuptools"
@@ -419,4 +446,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "ee5e2d69e3d8f249faabb7a33b1afb2144abb724aba4ca3dad81630d5f4e690c"
+content-hash = "1cf78c834ed877c223d637c4d12f61cac3dacaee02bc88a9d9ed754aec341105"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,104 @@ requests = "^2.31.0"
 pydantic = "<2, >=1"
 typing-extensions = "<4.6.0, >=3.6.6"
 
-
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.6.2"
+ruff = "^0.4.2"
+
+[tool.ruff]
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "venv",
+    "virtualenvs",
+]
+line-length = 120
+indent-width = 4
+target-version = "py310"
+
+[tool.ruff.lint]
+select = [
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pep8-naming
+    "N",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    "B",
+    # flake8-bandit
+    "S",
+    # flake8-blind-except
+    "BLE",
+    # flake8-builtins
+    "A",
+    # isort
+    "I",
+    # flake8-logging-format
+    "G",
+    # flake8-no-pep420
+    "INP",
+    # Ruff-specific rules
+    "RUF"
+]
+ignore = [
+  # Disable eradicate (commented code removal)
+  "ERA001",
+  # Disable Conflicting lint rules,
+  # see https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+  "W191",
+  "E501",
+  "E111",
+  "E117",
+  "D206",
+  "D300",
+  "Q000",
+  "Q001",
+  "Q002",
+  "Q003",
+  "COM812",
+  "COM819",
+  "ISC001",
+  "ISC002",
+  # Disable unused `noqa` directive
+  "RUF100",
+]
+# Allow unused variables when underscore-prefixed:
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.pycodestyle]
+ignore-overlong-task-comments = true
+
+[tool.ruff.lint.isort]
+section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
+lines-after-imports = 2
+
+[tool.ruff.lint.per-file-ignores]
+# Ignore "E402", "F403", "F405" (import violations) in __init__.py files.
+# Ignore "S" (flake8-bandit) and "N802" (function name should be lowercase) in tests and docs.
+# Ignore "RUF" (Ruff-specific rules) and "I" (isort) in migrations.
+"__init__.py" = ["E402", "F403", "F405"]
+"**/{tests,docs}/*" = ["E402", "F403", "F405", "S", "N802"]
+"**/*test*.py" = ["E402", "F403", "F405", "S", "N802"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
First stable release of dials-py.

- Update all models according to DIALS database schema in v1.0.0;
- Remove multi-threading fetch support, since DIALS shifted to a cursor based pagination approach;
- Update pre-commit (moved from black, flake8 and isort to ruff) and editorconfig config files.

More information of DIALS release can be found [here](https://github.com/cms-DQM/dials/releases/tag/v1.0.0).