### PR TITLE
feat: add support to retrieve and list data from `/mes` endpoint

### DIFF
--- a/cmsdials/clients/mes/client.py
+++ b/cmsdials/clients/mes/client.py
@@ -1,0 +1,8 @@
+from ...utils.api_client import BaseAuthorizedAPIClient
+from .models import MEFilters, MonitoringElement
+
+
+class MonitoringElementClient(BaseAuthorizedAPIClient):
+    data_model = MonitoringElement
+    filter_class = MEFilters
+    lookup_url = "mes/"

--- a/cmsdials/clients/mes/models.py
+++ b/cmsdials/clients/mes/models.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, Field
+
+from ...utils.base_model import OBaseModel
+
+
+class MonitoringElement(BaseModel):
+    me_id: int
+    me: str = Field(..., max_length=255)
+    count: int
+    dim: int
+
+
+class MEFilters(OBaseModel):
+    me: str | None = None
+    me__regex: str | None = None
+    dim: int | None = None

--- a/cmsdials/cmsdials.py
+++ b/cmsdials/cmsdials.py
@@ -1,17 +1,17 @@
-from typing import Optional
-
 from .auth._base import BaseCredentials
 from .clients.file_index.client import FileIndexClient
 from .clients.h1d.client import LumisectionHistogram1DClient
 from .clients.h2d.client import LumisectionHistogram2DClient
 from .clients.lumisection.client import LumisectionClient
+from .clients.mes.client import MonitoringElementClient
 from .clients.run.client import RunClient
 
 
 class Dials:
-    def __init__(self, creds: BaseCredentials, workspace: Optional[str] = None, *args, **kwargs) -> None:
+    def __init__(self, creds: BaseCredentials, workspace: str | None = None, *args, **kwargs) -> None:
         self.file_index = FileIndexClient(creds, workspace, *args, **kwargs)
         self.h1d = LumisectionHistogram1DClient(creds, workspace, *args, **kwargs)
         self.h2d = LumisectionHistogram2DClient(creds, workspace, *args, **kwargs)
         self.lumi = LumisectionClient(creds, workspace, *args, **kwargs)
         self.run = RunClient(creds, workspace, *args, **kwargs)
+        self.mes = MonitoringElementClient(creds, workspace, *args, **kwargs)

--- a/cmsdials/filters.py
+++ b/cmsdials/filters.py
@@ -2,7 +2,9 @@ from .clients.file_index.models import FileIndexFilters
 from .clients.h1d.models import LumisectionHistogram1DFilters
 from .clients.h2d.models import LumisectionHistogram2DFilters
 from .clients.lumisection.models import LumisectionFilters
+from .clients.mes.models import MEFilters
 from .clients.run.models import RunFilters
+
 
 __all__ = [
     "FileIndexFilters",
@@ -10,4 +12,5 @@ __all__ = [
     "LumisectionHistogram2DFilters",
     "LumisectionFilters",
     "RunFilters",
+    "MEFilters",
 ]


### PR DESCRIPTION
- Add `MonitoringElement`, `MEFilters` and `MonitoringElementClient`
- Minimal refactor on `BaseAuthorizedAPIClient` to support `pagination_class = None`, if a client is configured like this the `list_all` method will default to `list` and the `list` method will parse the output as an array of pydantic `data_model`.