### PR TITLE
Update package according to DIALS release 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ This package interacts with DIALS api endpoints using underlying classes in `Dia
 ### Retrieving a specific object using `get`
 
 ```python
-dials.file_index.get(id=3386119397)
-dials.h1d.get(id=1)
-dials.h2d.get(id=1)
-dials.lumi.get(dataset_id=14677060, run_number=367094, ls_number=1)
-dials.run.get(dataset_id=14677060, run_number=367094)
+dials.file_index.get(dataset_id=14677060, file_id=3393809397)
+dials.h1d.get(dataset_id=14677060, run_number=367112, ls_number=10, me_id=1)
+dials.h1d.get(dataset_id=14677060, run_number=367112, ls_number=10, me_id=96)
+dials.lumi.get(dataset_id=14677060, run_number=367112, ls_number=10)
+dials.run.get(dataset_id=14677060, run_number=367112)
 ```
 
 ### Retrieving a list of objects per page using `list`
@@ -202,3 +202,9 @@ SECRET_KEY=... pytest tests
 ```
 
 The secret key is an api client enabled secret key and can be obtained from the applications portal, any api client secret key whitelisted in DIALS can be used. The interactive authentication flow should be tested manually, an example for this can be found in [this line](/tests/integration/test_auth_client.py#L33).
+
+If testing against a local version of DIALS you need to specify the BASE_URL:
+
+```bash
+SECRET_KEY=... BASE_URl=http://localhost:8000 pytest tests
+```

--- a/cmsdials/clients/file_index/client.py
+++ b/cmsdials/clients/file_index/client.py
@@ -1,4 +1,8 @@
+import requests
+from requests.exceptions import HTTPError
+
 from ...utils.api_client import BaseAuthorizedAPIClient
+from ...utils.logger import logger
 from .models import FileIndex, FileIndexFilters, PaginatedFileIndexList
 
 
@@ -7,3 +11,17 @@ class FileIndexClient(BaseAuthorizedAPIClient):
     pagination_model = PaginatedFileIndexList
     filter_class = FileIndexFilters
     lookup_url = "file-index/"
+
+    def get(self, dataset_id: int, file_id: int):
+        endpoint_url = f"{self.api_url}{self.lookup_url}{dataset_id}/{file_id}/"
+        headers = self._build_headers()
+        response = requests.get(endpoint_url, headers=headers, timeout=self.default_timeout)
+
+        try:
+            response.raise_for_status()
+        except HTTPError as err:
+            logger.info(f"Api raw response: {response.text}")
+            raise err
+
+        response = response.json()
+        return self.data_model(**response)

--- a/cmsdials/clients/h1d/client.py
+++ b/cmsdials/clients/h1d/client.py
@@ -1,4 +1,8 @@
+import requests
+from requests.exceptions import HTTPError
+
 from ...utils.api_client import BaseAuthorizedAPIClient
+from ...utils.logger import logger
 from .models import LumisectionHistogram1D, LumisectionHistogram1DFilters, PaginatedLumisectionHistogram1DList
 
 
@@ -7,3 +11,17 @@ class LumisectionHistogram1DClient(BaseAuthorizedAPIClient):
     pagination_model = PaginatedLumisectionHistogram1DList
     filter_class = LumisectionHistogram1DFilters
     lookup_url = "th1/"
+
+    def get(self, dataset_id: int, run_number: int, ls_number: int, me_id: int):
+        endpoint_url = f"{self.api_url}{self.lookup_url}{dataset_id}/{run_number}/{ls_number}/{me_id}/"
+        headers = self._build_headers()
+        response = requests.get(endpoint_url, headers=headers, timeout=self.default_timeout)
+
+        try:
+            response.raise_for_status()
+        except HTTPError as err:
+            logger.info(f"Api raw response: {response.text}")
+            raise err
+
+        response = response.json()
+        return self.data_model(**response)

--- a/cmsdials/clients/h1d/models.py
+++ b/cmsdials/clients/h1d/models.py
@@ -6,7 +6,6 @@ from ...utils.base_model import OBaseModel, PaginatedBaseModel
 
 
 class LumisectionHistogram1D(BaseModel):
-    hist_id: int
     dataset: str = Field(..., max_length=255)
     me: str = Field(..., max_length=255)
     dataset_id: int

--- a/cmsdials/clients/h2d/client.py
+++ b/cmsdials/clients/h2d/client.py
@@ -1,4 +1,8 @@
+import requests
+from requests.exceptions import HTTPError
+
 from ...utils.api_client import BaseAuthorizedAPIClient
+from ...utils.logger import logger
 from .models import LumisectionHistogram2D, LumisectionHistogram2DFilters, PaginatedLumisectionHistogram2DList
 
 
@@ -7,3 +11,17 @@ class LumisectionHistogram2DClient(BaseAuthorizedAPIClient):
     pagination_model = PaginatedLumisectionHistogram2DList
     filter_class = LumisectionHistogram2DFilters
     lookup_url = "th2/"
+
+    def get(self, dataset_id: int, run_number: int, ls_number: int, me_id: int):
+        endpoint_url = f"{self.api_url}{self.lookup_url}{dataset_id}/{run_number}/{ls_number}/{me_id}/"
+        headers = self._build_headers()
+        response = requests.get(endpoint_url, headers=headers, timeout=self.default_timeout)
+
+        try:
+            response.raise_for_status()
+        except HTTPError as err:
+            logger.info(f"Api raw response: {response.text}")
+            raise err
+
+        response = response.json()
+        return self.data_model(**response)

--- a/cmsdials/clients/h2d/models.py
+++ b/cmsdials/clients/h2d/models.py
@@ -6,7 +6,6 @@ from ...utils.base_model import OBaseModel, PaginatedBaseModel
 
 
 class LumisectionHistogram2D(BaseModel):
-    hist_id: int
     dataset: str = Field(..., max_length=255)
     me: str = Field(..., max_length=255)
     dataset_id: int

--- a/tests/integration/test_file_index_client.py
+++ b/tests/integration/test_file_index_client.py
@@ -8,7 +8,7 @@ from .utils import setup_dials_object
 
 def test_get_file_index() -> None:
     dials = setup_dials_object()
-    data = dials.file_index.get(id=3386119397)
+    data = dials.file_index.get(dataset_id=14677060, file_id=3393809397)
     assert isinstance(data, FileIndex)
 
 

--- a/tests/integration/test_h1d_client.py
+++ b/tests/integration/test_h1d_client.py
@@ -8,7 +8,7 @@ from .utils import setup_dials_object
 
 def test_get_h1d() -> None:
     dials = setup_dials_object()
-    data = dials.h1d.get(id=1)
+    data = dials.h1d.get(dataset_id=14677060, run_number=367112, ls_number=10, me_id=1)
     assert isinstance(data, LumisectionHistogram1D)
 
 

--- a/tests/integration/test_h2d_client.py
+++ b/tests/integration/test_h2d_client.py
@@ -8,7 +8,7 @@ from .utils import setup_dials_object
 
 def test_get_h2d() -> None:
     dials = setup_dials_object()
-    data = dials.h2d.get(id=1)
+    data = dials.h2d.get(dataset_id=14677060, run_number=367112, ls_number=10, me_id=96)
     assert isinstance(data, LumisectionHistogram2D)
 
 

--- a/tests/integration/test_lumisection_client.py
+++ b/tests/integration/test_lumisection_client.py
@@ -8,7 +8,7 @@ from .utils import setup_dials_object
 
 def test_get_lumisection() -> None:
     dials = setup_dials_object()
-    data = dials.lumi.get(dataset_id=14677060, run_number=367094, ls_number=1)
+    data = dials.lumi.get(dataset_id=14677060, run_number=367112, ls_number=10)
     assert isinstance(data, Lumisection)
 
 

--- a/tests/integration/test_run_client.py
+++ b/tests/integration/test_run_client.py
@@ -8,7 +8,7 @@ from .utils import setup_dials_object
 
 def test_get_run() -> None:
     dials = setup_dials_object()
-    data = dials.run.get(dataset_id=14677060, run_number=367094)
+    data = dials.run.get(dataset_id=14677060, run_number=367112)
     assert isinstance(data, Run)
 
 

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -6,5 +6,6 @@ from cmsdials.auth.secret_key import Credentials
 
 def setup_dials_object() -> Dials:
     secret_key = os.getenv("SECRET_KEY")
+    base_url = os.getenv("BASE_URL")
     creds = Credentials(token=secret_key)
-    return Dials(creds)
+    return Dials(creds, base_url=base_url)


### PR DESCRIPTION
- Add get method to file_index, th1 and th2 clients with multiple args, since those tables are using a composite primary key and the base get method from BaseAuthorizedAPIClient only accepts one argument for the get method;
- Update th1 and th2 models, removing hist_id;
- Add possibility to run automated tests against local version of DIALS.