### PR TITLE
feat: support retrying

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,17 @@ Progress: 100%|█████████████████████�
 
 The total attribute of the bar is dynamically updated while fetching the pages.
 
+## Retrying
+
+In case of an unstable connection, DNS failures or service overload it is possible to configure any `list` and  `list_all` to retry the underlying requests using native `urllib3` retry class, for example:
+
+```python
+from urllib3.util import Retry
+
+data = dials.h1d.list(retries=Retry(total=3, backoff_factor=0.1))
+data = dials.h1d.list_all(LumisectionHistogram1DFilters(), max_pages=5, retries=Retry(total=5, backoff_factor=0.1))
+```
+
 ## Usage with local DIALS
 
 All classes that interface the DIALS service inherits the class `BaseAPIClient` which propagate the `base_url`, `route` and `version` attributes with production values. In order to use dials-py with a local version of DIALS it is possible to overwrite those attributes when instantiating the `AuthClient` and the `Dials` client, for example:

--- a/cmsdials/utils/api_client.py
+++ b/cmsdials/utils/api_client.py
@@ -94,11 +94,17 @@ class BaseAuthorizedAPIClient(BaseAPIClient):
         response = response.json()
         return self.data_model(**response)
 
-    def list(self, filters=None):
+    def list(self, filters=None, retries=DEFAULT_RETRIES):
         filters = filters or self.filter_class()
         endpoint_url = self.api_url + self.lookup_url
         headers = self._build_headers()
-        response = requests.get(endpoint_url, headers=headers, params=filters.cleandict(), timeout=self.default_timeout)
+        response = self._requests_get_retriable(
+            endpoint_url,
+            headers=headers,
+            params=filters.cleandict(),
+            timeout=self.default_timeout,
+            retries=retries,
+        )
 
         try:
             response.raise_for_status()
@@ -114,7 +120,13 @@ class BaseAuthorizedAPIClient(BaseAPIClient):
 
         raise ValueError("pagination model is None and response is not a list.")
 
-    def __list_sync(self, filters, max_pages: Optional[int] = None, enable_progress: bool = False):
+    def __list_sync(
+        self,
+        filters,
+        max_pages: Optional[int] = None,
+        enable_progress: bool = False,
+        retries=DEFAULT_RETRIES,
+    ):
         next_token = None
         results = []
         is_last_page = False
@@ -127,7 +139,7 @@ class BaseAuthorizedAPIClient(BaseAPIClient):
         while is_last_page is False:
             curr_filters = self.filter_class(**filters.dict())
             curr_filters.next_token = next_token
-            response = self.list(curr_filters)
+            response = self.list(curr_filters, retries=retries)
             results.extend(response.results)
             is_last_page = response.next is None
             next_token = parse_qs(urlparse(response.next).query).get("next_token") if response.next else None

--- a/cmsdials/utils/api_client.py
+++ b/cmsdials/utils/api_client.py
@@ -3,6 +3,8 @@ from typing import Optional
 from urllib.parse import parse_qs, urlparse
 
 import requests
+from requests import Response, Session
+from requests.adapters import DEFAULT_RETRIES, HTTPAdapter
 from requests.exceptions import HTTPError
 
 from ..auth._base import BaseCredentials
@@ -34,6 +36,19 @@ class BaseAPIClient:
         if value.endswith("/") is False:
             return value + "/"
         return value
+
+    @classmethod
+    def _requests_get_retriable(cls, *args, retries=DEFAULT_RETRIES, **kwargs) -> Response:
+        """
+        requests.get() with an additional `retries` parameter.
+
+        Specify retries=<number of attempts - 1> for simple use cases.
+        For advanced usage, see https://docs.python-requests.org/en/latest/user/advanced/
+        """
+        with Session() as s:
+            s.mount(cls.PRODUCTION_BASE_URL, HTTPAdapter(max_retries=retries))
+            ret = s.get(*args, **kwargs)
+        return ret
 
     @property
     def api_url(self):

--- a/poetry.lock
+++ b/poetry.lock
@@ -2379,13 +2379,13 @@ dev = ["flake8", "flake8-annotations", "flake8-bandit", "flake8-bugbear", "flake
 
 [[package]]
 name = "urllib3"
-version = "2.2.1"
+version = "2.2.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "urllib3-2.2.1-py3-none-any.whl", hash = "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"},
-    {file = "urllib3-2.2.1.tar.gz", hash = "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"},
+    {file = "urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac"},
+    {file = "urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"},
 ]
 
 [package.extras]
@@ -2489,4 +2489,4 @@ tqdm = ["tqdm"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "f4926205e175d0e73969451cbc833f93730c7ae6f62c119af023828d00515738"
+content-hash = "6b736773c5da03f3136bbd2ea6830ca9e601551e40a021e381d8b889b9432e78"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ pydantic = "<2, >=1"
 typing-extensions = "<4.6.0, >=3.6.6"
 pandas = {version = ">=1.5.3", optional = true}
 tqdm = {version = ">=4.66.1", optional = true}
+urllib3 = "^2.2.3"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.6.2"

--- a/tests/integration/test_h1d_client.py
+++ b/tests/integration/test_h1d_client.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from urllib3.util import Retry
 
 from cmsdials.clients.h1d.models import LumisectionHistogram1D, PaginatedLumisectionHistogram1DList
 from cmsdials.filters import LumisectionHistogram1DFilters
@@ -14,13 +15,13 @@ def test_get_h1d() -> None:
 
 def test_list_h1d() -> None:
     dials = setup_dials_object()
-    data = dials.h1d.list()
+    data = dials.h1d.list(retries=Retry(total=3, backoff_factor=0.1))
     assert isinstance(data, PaginatedLumisectionHistogram1DList)
     assert isinstance(data.to_pandas(), pd.DataFrame)
 
 
 def test_list_all_h1d() -> None:
     dials = setup_dials_object()
-    data = dials.h1d.list_all(LumisectionHistogram1DFilters(), max_pages=5)
+    data = dials.h1d.list_all(LumisectionHistogram1DFilters(), max_pages=5, retries=Retry(total=5, backoff_factor=0.1))
     assert isinstance(data, PaginatedLumisectionHistogram1DList)
     assert isinstance(data.to_pandas(), pd.DataFrame)

--- a/tests/integration/test_h2d_client.py
+++ b/tests/integration/test_h2d_client.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from urllib3.util import Retry
 
 from cmsdials.clients.h2d.models import LumisectionHistogram2D, PaginatedLumisectionHistogram2DList
 from cmsdials.filters import LumisectionHistogram2DFilters
@@ -14,13 +15,13 @@ def test_get_h2d() -> None:
 
 def test_list_h2d() -> None:
     dials = setup_dials_object()
-    data = dials.h2d.list()
+    data = dials.h2d.list(retries=Retry(total=3, backoff_factor=0.1))
     assert isinstance(data, PaginatedLumisectionHistogram2DList)
     assert isinstance(data.to_pandas(), pd.DataFrame)
 
 
 def test_list_all_h2d() -> None:
     dials = setup_dials_object()
-    data = dials.h2d.list_all(LumisectionHistogram2DFilters(), max_pages=5)
+    data = dials.h2d.list_all(LumisectionHistogram2DFilters(), max_pages=5, retries=Retry(total=5, backoff_factor=0.1))
     assert isinstance(data, PaginatedLumisectionHistogram2DList)
     assert isinstance(data.to_pandas(), pd.DataFrame)

--- a/tests/integration/test_h2d_client.py
+++ b/tests/integration/test_h2d_client.py
@@ -9,7 +9,7 @@ from .utils import setup_dials_object
 
 def test_get_h2d() -> None:
     dials = setup_dials_object()
-    data = dials.h2d.get(dataset_id=14677060, run_number=367112, ls_number=10, me_id=133)
+    data = dials.h2d.get(dataset_id=14677060, run_number=367112, ls_number=10, me_id=100)
     assert isinstance(data, LumisectionHistogram2D)
 
 


### PR DESCRIPTION
### Description

This pull request adds a parameter `retries` to methods `Dials.list` and `Dials.list_all`, backed by `urllib3.util.Retry` and `requests.adapters.HTTPAdapter`.

Long downloads are prone to network issues, which can be mitigated by adding retrying functionality. This PR forwards the `max_retries` parameter of `HTTPAdapter` as `retries` to `Dials.list` and `Dials.list_all` and provides the retrying functionality without additional dependencies.

![Screenshot_20240813_110549](https://github.com/user-attachments/assets/c9c739ca-e5b7-49c3-a381-2330d310997c)

### Progress

I'm testing the functionality by downloading 1D histograms of four MEs from `/JetMET0/Run2024D-PromptReco-v1/DQMIO`.

~How do I add and run the tests inside the source tree?~ Do you think I should also update the documentation?

Update: I now see the instructions in the README.md.