### PR TITLE
feat: support returning and resuming partial results

### DIFF
--- a/cmsdials/utils/api_client.py
+++ b/cmsdials/utils/api_client.py
@@ -1,5 +1,5 @@
 from importlib import util as importlib_util
-from traceback import format_exception_only
+from traceback import format_exc
 from typing import Optional
 from urllib.parse import parse_qs, urlparse
 from warnings import warn
@@ -165,7 +165,7 @@ class BaseAuthorizedAPIClient(BaseAPIClient):
                 if not keep_failed:
                     raise e
                 warn(
-                    "HTTP request failed, returning partial results. Exception: " + "\n".join(format_exception_only(e)),
+                    "HTTP request failed, returning partial results. Exception: " + format_exc(),
                     RuntimeWarning,
                     stacklevel=2,
                 )

--- a/cmsdials/utils/api_client.py
+++ b/cmsdials/utils/api_client.py
@@ -1,6 +1,8 @@
 from importlib import util as importlib_util
+from traceback import format_exception_only
 from typing import Optional
 from urllib.parse import parse_qs, urlparse
+from warnings import warn
 
 import requests
 from requests.exceptions import HTTPError
@@ -99,10 +101,29 @@ class BaseAuthorizedAPIClient(BaseAPIClient):
 
         raise ValueError("pagination model is None and response is not a list.")
 
-    def __list_sync(self, filters, max_pages: Optional[int] = None, enable_progress: bool = False):
-        next_token = None
+    def __list_sync(
+        self,
+        filters,
+        max_pages: Optional[int] = None,
+        enable_progress: bool = False,
+        keep_failed: bool = False,
+        resume_from=None,
+    ):
+        next_string: Optional[str] = None
         results = []
         is_last_page = False
+
+        if resume_from is not None:
+            results = resume_from.results
+            next_string = resume_from.next
+            if next_string is None and len(results):
+                warn(
+                    "resume_from.next is None while resume_from.result is not empty, doing nothing.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                is_last_page = True
+
         total_pages = 0
         use_tqdm = TQDM_INSTALLED and enable_progress
 
@@ -110,12 +131,31 @@ class BaseAuthorizedAPIClient(BaseAPIClient):
             progress = tqdm(desc="Progress", total=1)
 
         while is_last_page is False:
+            next_token = parse_qs(urlparse(next_string).query).get("next_token") if next_string else None
             curr_filters = self.filter_class(**filters.dict())
             curr_filters.next_token = next_token
-            response = self.list(curr_filters)
+            try:
+                response = self.list(curr_filters)
+            except Exception as e:
+                if use_tqdm:
+                    progress.close()
+
+                if not keep_failed:
+                    raise e
+                warn(
+                    "HTTP request failed, returning partial results. Exception: " + "\n".join(format_exception_only(e)),
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                return self.pagination_model(
+                    next=next_string,
+                    previous=None,
+                    results=results,
+                    exception=e,
+                )
             results.extend(response.results)
-            is_last_page = response.next is None
-            next_token = parse_qs(urlparse(response.next).query).get("next_token") if response.next else None
+            next_string = response.next
+            is_last_page = next_string is None
             total_pages += 1
             max_pages_reached = max_pages and total_pages >= max_pages
             if use_tqdm:

--- a/cmsdials/utils/api_client.py
+++ b/cmsdials/utils/api_client.py
@@ -164,6 +164,7 @@ class BaseAuthorizedAPIClient(BaseAPIClient):
 
                 if not keep_failed:
                     raise e
+
                 exc_formatted = format_exc()
                 warn(
                     "HTTP request failed, returning partial results. Exception: " + exc_formatted,
@@ -195,7 +196,7 @@ class BaseAuthorizedAPIClient(BaseAPIClient):
             progress.close()
 
         return self.pagination_model(
-            next=None,
+            next=next_string,
             previous=None,
             results=results,  # No problem re-using last response count
         )

--- a/cmsdials/utils/api_client.py
+++ b/cmsdials/utils/api_client.py
@@ -164,8 +164,9 @@ class BaseAuthorizedAPIClient(BaseAPIClient):
 
                 if not keep_failed:
                     raise e
+                exc_formatted = format_exc()
                 warn(
-                    "HTTP request failed, returning partial results. Exception: " + format_exc(),
+                    "HTTP request failed, returning partial results. Exception: " + exc_formatted,
                     RuntimeWarning,
                     stacklevel=2,
                 )
@@ -173,7 +174,8 @@ class BaseAuthorizedAPIClient(BaseAPIClient):
                     next=next_string,
                     previous=None,
                     results=results,
-                    exception=e,
+                    exc_type=e.__class__.__name__,
+                    exc_formatted=exc_formatted,
                 )
             results.extend(response.results)
             next_string = response.next

--- a/cmsdials/utils/base_model.py
+++ b/cmsdials/utils/base_model.py
@@ -1,7 +1,7 @@
 from importlib import util as importlib_util
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
 if importlib_util.find_spec("pandas"):
@@ -18,10 +18,8 @@ class OBaseModel(BaseModel):
 
 
 class PaginatedBaseModel(BaseModel):
-    class Config:
-        arbitrary_types_allowed = True
-
-    exception: Optional[BaseException] = Field(default=None)
+    exc_type: Optional[str] = None
+    exc_formatted: Optional[str] = None
 
     def to_pandas(self):
         if PANDAS_NOT_INSTALLED:

--- a/cmsdials/utils/base_model.py
+++ b/cmsdials/utils/base_model.py
@@ -1,6 +1,7 @@
 from importlib import util as importlib_util
+from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 if importlib_util.find_spec("pandas"):
@@ -17,6 +18,11 @@ class OBaseModel(BaseModel):
 
 
 class PaginatedBaseModel(BaseModel):
+    class Config:
+        arbitrary_types_allowed = True
+
+    exception: Optional[BaseException] = Field(default=None)
+
     def to_pandas(self):
         if PANDAS_NOT_INSTALLED:
             raise RuntimeError(

--- a/tests/integration/test_resume.py
+++ b/tests/integration/test_resume.py
@@ -1,0 +1,22 @@
+from cmsdials.filters import LumisectionHistogram2DFilters
+
+from .utils import setup_dials_object
+
+
+def test_resume() -> None:
+    dials = setup_dials_object(workspace="tracker")
+    data = dials.h2d.list_all(
+        LumisectionHistogram2DFilters(me__regex="PXBarrel", ls_number=78, entries__gte=100),
+        max_pages=10,
+        keep_failed=True,
+    )
+    assert len(data.results) == 100
+    data = dials.h2d.list_all(
+        LumisectionHistogram2DFilters(me__regex="PXBarrel", ls_number=78, entries__gte=100),
+        max_pages=10,
+        keep_failed=True,
+        resume_from=data,
+    )
+    assert len(data.results) == 200
+    assert data.results[0].run_number != data.results[100].run_number
+    assert data.results[100].run_number != data.results[199].run_number

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -1,11 +1,12 @@
 import os
+from typing import Optional
 
 from cmsdials import Dials
 from cmsdials.auth.secret_key import Credentials
 
 
-def setup_dials_object() -> Dials:
+def setup_dials_object(workspace: Optional[str] = None) -> Dials:
     secret_key = os.getenv("SECRET_KEY")
     base_url = os.getenv("BASE_URL")
     creds = Credentials(token=secret_key)
-    return Dials(creds, base_url=base_url)
+    return Dials(creds, base_url=base_url, workspace=workspace)


### PR DESCRIPTION
### Description

Add a parameter `keep_failed` to `Dials.list_all()`, specifying whether to return the paginated partial results when an HTTP request fails.

Add a parameter `resume_from` to `Dials.list_all()` to accept paginated partial results and resume the fetching.

Add a field `exception` to `PaginatedBaseModel` to record the exception that causes the request to fail.

If applied, users would be able to write something like:
```python
data = None
data = dials.h1d.list_all(<filter>, keep_failed=True, resume_from=data)
```
and resume by <kbd>Up</kbd><kbd>Enter</kbd> from the terminal.

### TODO

*   Update the documentation.
*   Run the tests.